### PR TITLE
Prevent profile access and nav flicker when logged out

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -53,7 +53,7 @@
         <a
           href="../profile/"
           data-user-only
-          class="text-navy hover:text-yellow text-4xl"
+          class="hidden text-navy hover:text-yellow text-4xl"
           aria-label="profile"
           ><i class="fa-solid fa-circle-user"></i
         ></a>
@@ -61,7 +61,7 @@
         <a
           href="../listings/create.html"
           data-user-only
-          class="bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
+          class="hidden bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
         >
           <i class="fa-solid fa-plus"></i> New listing
         </a>
@@ -70,7 +70,7 @@
           href="#"
           data-user-only
           data-logout
-          class="text-navy hover:text-red font-medium"
+          class="hidden text-navy hover:text-red font-medium"
         >
           <i class="fa-solid fa-right-from-bracket"></i> Logout
         </a>

--- a/auth/login.html
+++ b/auth/login.html
@@ -54,7 +54,7 @@
         <a
           href="../profile/"
           data-user-only
-          class="text-navy hover:text-yellow text-4xl"
+          class="hidden text-navy hover:text-yellow text-4xl"
           aria-label="profile"
           ><i class="fa-solid fa-circle-user"></i
         ></a>
@@ -62,7 +62,7 @@
         <a
           href="../listings/create.html"
           data-user-only
-          class="bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
+          class="hidden bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
         >
           <i class="fa-solid fa-plus"></i> New listing
         </a>
@@ -71,7 +71,7 @@
           href="#"
           data-user-only
           data-logout
-          class="text-navy hover:text-red font-medium"
+          class="hidden text-navy hover:text-red font-medium"
         >
           <i class="fa-solid fa-right-from-bracket"></i> Logout
         </a>

--- a/css/style.css
+++ b/css/style.css
@@ -592,6 +592,10 @@ video {
   visibility: visible;
 }
 
+.collapse {
+  visibility: collapse;
+}
+
 .static {
   position: static;
 }
@@ -608,6 +612,10 @@ video {
   position: relative;
 }
 
+.sticky {
+  position: sticky;
+}
+
 .inset-0 {
   inset: 0px;
 }
@@ -616,8 +624,40 @@ video {
   top: -2.5rem;
 }
 
+.bottom-1 {
+  bottom: 0.25rem;
+}
+
+.bottom-4 {
+  bottom: 1rem;
+}
+
+.end-1 {
+  inset-inline-end: 0.25rem;
+}
+
+.left-1 {
+  left: 0.25rem;
+}
+
+.left-5 {
+  left: 1.25rem;
+}
+
 .right-0 {
   right: 0px;
+}
+
+.start-1 {
+  inset-inline-start: 0.25rem;
+}
+
+.top-3 {
+  top: 0.75rem;
+}
+
+.top-5 {
+  top: 1.25rem;
 }
 
 .z-20 {
@@ -650,6 +690,10 @@ video {
 
 .m-4 {
   margin: 1rem;
+}
+
+.m-40 {
+  margin: 10rem;
 }
 
 .m-5 {
@@ -837,6 +881,10 @@ video {
   display: block;
 }
 
+.inline-block {
+  display: inline-block;
+}
+
 .inline {
   display: inline;
 }
@@ -853,12 +901,69 @@ video {
   display: table;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
+.table-caption {
+  display: table-caption;
+}
+
+.table-cell {
+  display: table-cell;
+}
+
+.table-column {
+  display: table-column;
+}
+
+.table-column-group {
+  display: table-column-group;
+}
+
+.table-footer-group {
+  display: table-footer-group;
+}
+
+.table-header-group {
+  display: table-header-group;
+}
+
+.table-row-group {
+  display: table-row-group;
+}
+
+.table-row {
+  display: table-row;
+}
+
 .grid {
   display: grid;
 }
 
+.inline-grid {
+  display: inline-grid;
+}
+
+.contents {
+  display: contents;
+}
+
+.list-item {
+  display: list-item;
+}
+
 .hidden {
   display: none;
+}
+
+.size-1 {
+  width: 0.25rem;
+  height: 0.25rem;
+}
+
+.h-1 {
+  height: 0.25rem;
 }
 
 .h-12 {
@@ -904,6 +1009,10 @@ video {
 
 .min-h-screen {
   min-height: 100vh;
+}
+
+.w-1 {
+  width: 0.25rem;
 }
 
 .w-12 {
@@ -962,8 +1071,16 @@ video {
   flex: 1 1 0%;
 }
 
+.flex-shrink {
+  flex-shrink: 1;
+}
+
 .flex-grow {
   flex-grow: 1;
+}
+
+.border-collapse {
+  border-collapse: collapse;
 }
 
 .transform {
@@ -1064,12 +1181,24 @@ video {
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
 }
 
+.self-start {
+  align-self: flex-start;
+}
+
 .self-end {
   align-self: flex-end;
 }
 
 .overflow-hidden {
   overflow: hidden;
+}
+
+.text-wrap {
+  text-wrap: wrap;
+}
+
+.break-all {
+  word-break: break-all;
 }
 
 .rounded {
@@ -1122,11 +1251,6 @@ video {
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
-}
-
-.border-red {
-  --tw-border-opacity: 1;
-  border-color: rgb(255 0 0 / var(--tw-border-opacity, 1));
 }
 
 .border-yellow {
@@ -1357,6 +1481,10 @@ video {
   text-align: right;
 }
 
+.text-justify {
+  text-align: justify;
+}
+
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -1409,8 +1537,25 @@ video {
   font-weight: 600;
 }
 
+.uppercase {
+  text-transform: uppercase;
+}
+
+.lowercase {
+  text-transform: lowercase;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
 .italic {
   font-style: italic;
+}
+
+.ordinal {
+  --tw-ordinal: ordinal;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
 }
 
 .leading-none {
@@ -1491,6 +1636,16 @@ video {
   text-decoration-line: line-through;
 }
 
+.antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.subpixel-antialiased {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
 .opacity-50 {
   opacity: 0.5;
 }
@@ -1507,13 +1662,42 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.outline {
+  outline-style: solid;
+}
+
 .blur {
   --tw-blur: blur(8px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
+.drop-shadow {
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.grayscale {
+  --tw-grayscale: grayscale(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.invert {
+  --tw-invert: invert(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.sepia {
+  --tw-sepia: sepia(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.backdrop-filter {
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
 
 .transition {
@@ -1522,6 +1706,22 @@ video {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
+}
+
+.ease-in {
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.\[a-z_\:\.\\-\] {
+  a-z_: .\-;
 }
 
 .placeholder\:text-gray-400::-moz-placeholder {
@@ -1569,14 +1769,14 @@ video {
   color: rgb(255 0 0 / var(--tw-text-opacity, 1));
 }
 
-.hover\:text-yellow:hover {
-  --tw-text-opacity: 1;
-  color: rgb(252 163 17 / var(--tw-text-opacity, 1));
-}
-
 .hover\:text-white:hover {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-yellow:hover {
+  --tw-text-opacity: 1;
+  color: rgb(252 163 17 / var(--tw-text-opacity, 1));
 }
 
 .hover\:underline:hover {
@@ -1728,16 +1928,12 @@ video {
 }
 
 @media (min-width: 1280px) {
-  .xl\:grid-cols-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .xl\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .xl\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .xl\:grid-cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         <a
           href="./profile/"
           data-user-only
-          class="text-navy hover:text-yellow text-4xl"
+          class="hidden text-navy hover:text-yellow text-4xl"
           aria-label="profile"
           ><i class="fa-solid fa-circle-user"></i
         ></a>
@@ -61,7 +61,7 @@
         <a
           href="./listings/create.html"
           data-user-only
-          class="bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
+          class="hidden bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
         >
           <i class="fa-solid fa-plus"></i> New listing
         </a>
@@ -70,7 +70,7 @@
           href="#"
           data-user-only
           data-logout
-          class="text-navy hover:text-red font-medium"
+          class="hidden text-navy hover:text-red font-medium"
         >
           <i class="fa-solid fa-right-from-bracket"></i> Logout
         </a>

--- a/js/pages/listing-create-page.js
+++ b/js/pages/listing-create-page.js
@@ -4,8 +4,10 @@ setupAuthUI();
 import { logout, requireAuth } from "../script.js";
 import { createListing } from "../listings.js";
 
-// must be logged in to create a listing
-requireAuth("../index.html");
+// must be logged in to view profile
+if (!requireAuth()) {
+  throw new Error("Not authenticated");
+}
 
 // ---------- logout ----------
 const logoutLinks = document.querySelectorAll("[data-logout]");

--- a/js/pages/profile-page.js
+++ b/js/pages/profile-page.js
@@ -11,7 +11,10 @@ import {
 } from "../profiles.js";
 
 // must be logged in to view profile
-requireAuth("../index.html");
+if (!requireAuth()) {
+  throw new Error("Not authenticated");
+}
+
 
 // ---------- logout ----------
 const logoutLinks = document.querySelectorAll("[data-logout]");

--- a/js/script.js
+++ b/js/script.js
@@ -40,6 +40,7 @@ export function readJWT() {
 }
 
 export function requireAuth(redirectTo) {
+  // If no token, redirect to main page since not everything is protected and we don't want to break the UX by forcing login for everyone
   if (!redirectTo) redirectTo = "../index.html";
 
   const token = localStorage.getItem(TOKEN_KEY);

--- a/js/ui/auth-ui.js
+++ b/js/ui/auth-ui.js
@@ -9,12 +9,12 @@ export function setupAuthUI() {
 
   // show/hide guest-only
   for (let i = 0; i < guestOnly.length; i++) {
-    guestOnly[i].style.display = isLoggedIn ? "none" : "";
+    guestOnly[i].classList.toggle("hidden", isLoggedIn);
   }
 
   // show/hide user-only
   for (let i = 0; i < userOnly.length; i++) {
-    userOnly[i].style.display = isLoggedIn ? "" : "none";
+    userOnly[i].classList.toggle("hidden", !isLoggedIn);
   }
 
   // set credits if element exists

--- a/listings/create.html
+++ b/listings/create.html
@@ -53,7 +53,7 @@
         <a
           href="../profile/"
           data-user-only
-          class="text-navy hover:text-yellow text-4xl"
+          class="hidden text-navy hover:text-yellow text-4xl"
           aria-label="profile"
           ><i class="fa-solid fa-circle-user"></i
         ></a>
@@ -61,7 +61,7 @@
         <a
           href="../listings/create.html"
           data-user-only
-          class="bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
+          class="hidden bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
         >
           <i class="fa-solid fa-plus"></i> New listing
         </a>
@@ -70,7 +70,7 @@
           href="#"
           data-user-only
           data-logout
-          class="text-navy hover:text-red font-medium"
+          class="hidden text-navy hover:text-red font-medium"
         >
           <i class="fa-solid fa-right-from-bracket"></i> Logout
         </a>

--- a/listings/details.html
+++ b/listings/details.html
@@ -56,7 +56,7 @@
         <a
           href="../profile/"
           data-user-only
-          class="text-navy hover:text-yellow text-4xl"
+          class="hidden text-navy hover:text-yellow text-4xl"
           aria-label="profile"
         >
           <i class="fa-solid fa-circle-user"></i>
@@ -65,7 +65,7 @@
         <a
           href="../listings/create.html"
           data-user-only
-          class="bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
+          class="hidden bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
         >
           <i class="fa-solid fa-plus"></i> New listing
         </a>
@@ -74,7 +74,7 @@
           href="#"
           data-user-only
           data-logout
-          class="text-navy hover:text-red font-medium"
+          class="hidden text-navy hover:text-red font-medium"
         >
           <i class="fa-solid fa-right-from-bracket"></i> Logout
         </a>

--- a/profile/index.html
+++ b/profile/index.html
@@ -53,7 +53,7 @@
         <a
           href="../profile/"
           data-user-only
-          class="text-navy hover:text-yellow text-4xl"
+          class="hidden text-navy hover:text-yellow text-4xl"
           aria-label="profile"
           ><i class="fa-solid fa-circle-user"></i
         ></a>
@@ -61,7 +61,7 @@
         <a
           href="../listings/create.html"
           data-user-only
-          class="bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
+          class="hidden bg-yellow text-black px-6 py-3 rounded-full hover:bg-navy hover:text-yellow font-medium"
         >
           <i class="fa-solid fa-plus"></i> New listing
         </a>
@@ -70,7 +70,7 @@
           href="#"
           data-user-only
           data-logout
-          class="text-navy hover:text-red font-medium"
+          class="hidden text-navy hover:text-red font-medium"
         >
           <i class="fa-solid fa-right-from-bracket"></i> Logout
         </a>


### PR DESCRIPTION
I noticed that unauthenticated users could access the profile page and briefly see partial UI.
This PR adds an authentication guard to redirect users early and stop further script execution.
Auth-only navigation elements are now hidden by default and only shown after authentication to prevent UI flicker.